### PR TITLE
Font Colors: Better support for Dark Themes

### DIFF
--- a/MassBattles/MassBattleWindowTemplates.xml
+++ b/MassBattles/MassBattleWindowTemplates.xml
@@ -1399,6 +1399,12 @@
       </script>
     </genericcontrol>
   </template>
+  <template name="mbLabel">
+    <cttitle_base>
+	  <label>
+	  </label>
+	</cttitle_base>
+  </template>
   <font name="battle_impact_font">
     <ttf file="graphics/fonts/Noto_Sans/NotoSans-Bold.ttf" name="Noto Sans Bold" size="24" />
     <color value="000000" />

--- a/MassBattles/MassBattleWindow_client.xml
+++ b/MassBattles/MassBattleWindow_client.xml
@@ -48,7 +48,7 @@
         <massbattle_left_anchor name="mb_left_anchor"/>
         <massbattle_right_anchor name="mb_right_anchor"/>
         <massbattle_center_anchor name="mb_center_anchor"/>
-        <label name="ForceTokensLabel">
+        <mbLabel name="ForceTokensLabel">
           <anchored>
             <bottom anchor="top" offset="80"/>
             <left parent="mb_center_anchor" anchor="left" offset="-41"/>
@@ -56,7 +56,7 @@
           </anchored>
           <center/>
           <static textres="massbattle_forcetokens_label"/>
-        </label>
+        </mbLabel>
         <number name="ForceTokensA">
           <readonly/>
           <anchored width="40" height="40">
@@ -133,62 +133,62 @@
             <bottom parent="round_label" anchor="top" offset="-10" />
           </anchored>
         </subwindow>
-        <label name="FtgLabelA">
+        <mbLabel name="FtgLabelA">
           <static textres="mb_fatigue_short_label"/>
           <anchored>
             <bottom parent="ArmyA" anchor="top"/>
             <right parent="ArmyA" anchor="right" offset="-80"/>
           </anchored>
-        </label>
-        <label name="WndLabelA">
+        </mbLabel>
+        <mbLabel name="WndLabelA">
           <static textres="mb_wound_short_label"/>
           <anchored>
             <bottom parent="ArmyA" anchor="top"/>
             <right parent="ArmyA" anchor="right" offset="-112"/>
           </anchored>
-        </label>
-        <label name="FtgLabelB">
+        </mbLabel>
+        <mbLabel name="FtgLabelB">
           <static textres="mb_fatigue_short_label"/>
           <anchored>
             <bottom parent="ArmyB" anchor="top"/>
             <right parent="ArmyB" anchor="right" offset="-80"/>
           </anchored>
-        </label>
-        <label name="WndLabelB">
+        </mbLabel>
+        <mbLabel name="WndLabelB">
           <static textres="mb_wound_short_label"/>
           <anchored>
             <bottom parent="ArmyB" anchor="top"/>
             <right parent="ArmyB" anchor="right" offset="-112"/>
           </anchored>
-        </label>
-        <label name="NamesLabelA">
+        </mbLabel>
+        <mbLabel name="NamesLabelA">
           <static textres="mb_name_short_label"/>
           <anchored>
             <bottom parent="ArmyA" anchor="top"/>
             <left parent="ArmyA" anchor="left" offset="110"/>
           </anchored>
-        </label>
-        <label name="SupportLabelA">
+        </mbLabel>
+        <mbLabel name="SupportLabelA">
           <static textres="mb_bonus_short_label"/>
           <anchored>
             <bottom parent="ArmyA" anchor="top"/>
             <left parent="ArmyA" anchor="left" offset="25"/>
           </anchored>
-        </label>
-        <label name="NamesLabelB">
+        </mbLabel>
+        <mbLabel name="NamesLabelB">
           <static textres="mb_name_short_label"/>
           <anchored>
             <bottom parent="ArmyB" anchor="top"/>
             <left parent="ArmyB" anchor="left" offset="110"/>
           </anchored>
-        </label>
-        <label name="SupportLabelB">
+        </mbLabel>
+        <mbLabel name="SupportLabelB">
           <static textres="mb_bonus_short_label"/>
           <anchored>
             <bottom parent="ArmyB" anchor="top"/>
             <left parent="ArmyB" anchor="left" offset="25"/>
           </anchored>
-        </label>
+        </mbLabel>
         <stringfield name="ArmyAName">
           <anchored>
             <top offset="25"/>
@@ -220,20 +220,20 @@
           <activate/>
           <fastinit/>
         </subwindow>
-        <label name="commanderALabel">
+        <mbLabel name="commanderALabel">
           <anchored>
             <left parent="leaderASlot"/>
             <bottom anchor="top" parent="leaderASlot"/>
           </anchored>
           <static textres="mb_commander_label"/>
-        </label>
-        <label name="commanderBLabel">
+        </mbLabel>
+        <mbLabel name="commanderBLabel">
           <anchored>
             <left parent="leaderBSlot"/>
             <bottom anchor="top" parent="leaderBSlot"/>
           </anchored>
           <static textres="mb_commander_label"/>
-        </label>
+        </mbLabel>
       </sheetdata>
     </windowclass>
 </root>

--- a/MassBattles/MassBattleWindow_host.xml
+++ b/MassBattles/MassBattleWindow_host.xml
@@ -48,7 +48,7 @@
         <massbattle_left_anchor name="mb_left_anchor"/>
         <massbattle_right_anchor name="mb_right_anchor"/>
         <massbattle_center_anchor name="mb_center_anchor"/>
-        <label name="ForceTokensLabel">
+        <mbLabel name="ForceTokensLabel">
           <anchored>
             <bottom anchor="top" offset="80"/>
             <left parent="mb_center_anchor" anchor="left" offset="-41"/>
@@ -56,7 +56,7 @@
           </anchored>
           <center/>
           <static textres="massbattle_forcetokens_label"/>
-        </label>
+        </mbLabel>
         <number name="ForceTokensA">
           <anchored width="40" height="40">
             <top parent="ForceTokensLabel" anchor="top" offset="-10"/>
@@ -147,62 +147,62 @@
             <bottom parent="round_label" anchor="top" offset="-10" />
 	    </anchored>
         </subwindow>
-        <label name="FtgLabelA">
+        <mbLabel name="FtgLabelA">
           <static textres="mb_fatigue_short_label"/>
           <anchored>
             <bottom parent="ArmyA" anchor="top"/>
             <right parent="ArmyA" anchor="right" offset="-80"/>
           </anchored>
-        </label>
-        <label name="WndLabelA">
+        </mbLabel>
+        <mbLabel name="WndLabelA">
           <static textres="mb_wound_short_label"/>
           <anchored>
             <bottom parent="ArmyA" anchor="top"/>
             <right parent="ArmyA" anchor="right" offset="-112"/>
           </anchored>
-        </label>
-        <label name="FtgLabelB">
+        </mbLabel>
+        <mbLabel name="FtgLabelB">
           <static textres="mb_fatigue_short_label"/>
           <anchored>
             <bottom parent="ArmyB" anchor="top"/>
             <right parent="ArmyB" anchor="right" offset="-80"/>
           </anchored>
-        </label>
-        <label name="WndLabelB">
+        </mbLabel>
+        <mbLabel name="WndLabelB">
           <static textres="mb_wound_short_label"/>
           <anchored>
             <bottom parent="ArmyB" anchor="top"/>
             <right parent="ArmyB" anchor="right" offset="-112"/>
           </anchored>
-        </label>
-        <label name="NamesLabelA">
+        </mbLabel>
+        <mbLabel name="NamesLabelA">
           <static textres="mb_name_short_label"/>
           <anchored>
             <bottom parent="ArmyA" anchor="top"/>
             <left parent="ArmyA" anchor="left" offset="110"/>
           </anchored>
-        </label>
-        <label name="SupportLabelA">
+        </mbLabel>
+        <mbLabel name="SupportLabelA">
           <static textres="mb_bonus_short_label"/>
           <anchored>
             <bottom parent="ArmyA" anchor="top"/>
             <left parent="ArmyA" anchor="left" offset="25"/>
           </anchored>
-        </label>
-        <label name="NamesLabelB">
+        </mbLabel>
+        <mbLabel name="NamesLabelB">
           <static textres="mb_name_short_label"/>
           <anchored>
             <bottom parent="ArmyB" anchor="top"/>
             <left parent="ArmyB" anchor="left" offset="110"/>
           </anchored>
-        </label>
-        <label name="SupportLabelB">
+        </mbLabel>
+        <mbLabel name="SupportLabelB">
           <static textres="mb_bonus_short_label"/>
           <anchored>
             <bottom parent="ArmyB" anchor="top"/>
             <left parent="ArmyB" anchor="left" offset="25"/>
           </anchored>
-        </label>
+        </mbLabel>
         
         <stringfield name="ArmyAName">
           <anchored>
@@ -259,20 +259,20 @@
           <activate/>
           <fastinit/>
         </subwindow>
-        <label name="commanderALabel">
+        <mbLabel name="commanderALabel">
           <anchored>
             <left parent="leaderASlot"/>
             <bottom anchor="top" parent="leaderASlot"/>
           </anchored>
           <static textres="mb_commander_label"/>
-        </label>
-        <label name="commanderBLabel">
+        </mbLabel>
+        <mbLabel name="commanderBLabel">
           <anchored>
             <left parent="leaderBSlot"/>
             <bottom anchor="top" parent="leaderBSlot"/>
           </anchored>
           <static textres="mb_commander_label"/>
-        </label>
+        </mbLabel>
       </sheetdata>
     </windowclass>
 </root>


### PR DESCRIPTION
As discussed [here](https://www.fantasygrounds.com/forums/showthread.php?64262-Extension-New-Extension-Mass-Battles&p=621027&viewfull=1#post621027) the extension struggles with dark themes. While there are still some fonts I have not yet been able to figure out how to properly turn white on dark themes, the labels should now be either white or black depending on the chosen theme.